### PR TITLE
Add licensing and housekeeping assets to Fever module

### DIFF
--- a/MMM-WNBAFeverStats/.gitignore
+++ b/MMM-WNBAFeverStats/.gitignore
@@ -1,0 +1,30 @@
+# Dependency directories
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+.DS_Store
+
+# Coverage directories
+coverage/
+
+# Build outputs
+/dist/
+/build/
+
+# Environment files
+.env
+.env.*
+
+# Lock and cache files created by package managers
+.pnpm-store/
+.npm/
+.cache/
+
+# MagicMirror config overrides
+config.js
+

--- a/MMM-WNBAFeverStats/LICENSE
+++ b/MMM-WNBAFeverStats/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 MMM-WNBAFeverStats contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MMM-WNBAFeverStats/MMM-WNBAFeverStats.css
+++ b/MMM-WNBAFeverStats/MMM-WNBAFeverStats.css
@@ -1,0 +1,84 @@
+.mmm-wnba-fever-stats {
+  font-size: 16px;
+  line-height: 1.4;
+}
+
+.mmm-wnba-fever-stats .loading,
+.mmm-wnba-fever-stats .error,
+.mmm-wnba-fever-stats .no-data {
+  text-align: center;
+  padding: 0.5rem 0;
+}
+
+.mmm-wnba-fever-stats .section-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.mmm-wnba-fever-stats .section-title .status {
+  color: #ff4081;
+  margin-right: 0.5rem;
+}
+
+.mmm-wnba-fever-stats .section-title .matchup {
+  font-weight: 700;
+}
+
+.mmm-wnba-fever-stats .venue {
+  font-size: 0.9em;
+  color: #aaa;
+  margin-bottom: 0.75rem;
+}
+
+.mmm-wnba-fever-stats .stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0.75rem;
+}
+
+.mmm-wnba-fever-stats .stats-table th,
+.mmm-wnba-fever-stats .stats-table td {
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.mmm-wnba-fever-stats .stats-table th {
+  font-size: 0.85em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.mmm-wnba-fever-stats .stats-table td {
+  font-size: 0.95em;
+}
+
+.mmm-wnba-fever-stats .stats-table td.player {
+  font-weight: 600;
+}
+
+.mmm-wnba-fever-stats .upcoming-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.mmm-wnba-fever-stats .upcoming-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.mmm-wnba-fever-stats .upcoming-list li:last-child {
+  border-bottom: none;
+}
+
+.mmm-wnba-fever-stats .upcoming-list .opponent {
+  display: inline-block;
+  min-width: 8rem;
+  font-weight: 600;
+}
+
+.mmm-wnba-fever-stats .upcoming-list .datetime {
+  margin-left: 0.5rem;
+  color: #ccc;
+}

--- a/MMM-WNBAFeverStats/MMM-WNBAFeverStats.js
+++ b/MMM-WNBAFeverStats/MMM-WNBAFeverStats.js
@@ -1,0 +1,189 @@
+/* global Module */
+
+Module.register("MMM-WNBAFeverStats", {
+  defaults: {
+    favoriteTeamId: "ind",
+    favoriteTeamDisplayName: "Indiana Fever",
+    updateInterval: 5 * 60 * 1000,
+    animationSpeed: 1000,
+    maxUpcoming: 3,
+    headerText: "Indiana Fever Live Stats"
+  },
+
+  start() {
+    this.loaded = false;
+    this.error = null;
+    this.liveGame = null;
+    this.upcomingGames = [];
+    this.sendSocketNotification("CONFIG", this.config);
+  },
+
+  getHeader() {
+    return this.config.headerText;
+  },
+
+  getStyles() {
+    return ["MMM-WNBAFeverStats.css"];
+  },
+
+  socketNotificationReceived(notification, payload) {
+    if (notification === "GAME_DATA") {
+      this.error = null;
+      this.loaded = true;
+      this.liveGame = payload.liveGame;
+      this.upcomingGames = payload.upcomingGames;
+      this.updateDom(this.config.animationSpeed);
+    } else if (notification === "GAME_ERROR") {
+      this.error = payload.message;
+      this.loaded = true;
+      this.liveGame = null;
+      this.upcomingGames = [];
+      this.updateDom(this.config.animationSpeed);
+    }
+  },
+
+  getDom() {
+    const wrapper = document.createElement("div");
+    wrapper.className = "mmm-wnba-fever-stats";
+
+    if (!this.loaded) {
+      wrapper.innerHTML = `<div class="loading">Loading ${this.config.favoriteTeamDisplayName} data...</div>`;
+      return wrapper;
+    }
+
+    if (this.error) {
+      wrapper.innerHTML = `<div class="error">${this.translate("ERROR")}: ${this.error}</div>`;
+      return wrapper;
+    }
+
+    if (this.liveGame) {
+      wrapper.appendChild(this.renderLiveGame());
+    } else {
+      wrapper.appendChild(this.renderUpcoming());
+    }
+
+    return wrapper;
+  },
+
+  renderLiveGame() {
+    const container = document.createElement("div");
+    container.className = "live-game";
+
+    const title = document.createElement("div");
+    title.className = "section-title";
+    const matchup = `${this.config.favoriteTeamDisplayName} ${this.liveGame.teamScore} - ${this.liveGame.opponentScore} ${this.liveGame.opponent}`;
+    title.innerHTML = `<span class="status">${this.liveGame.status}</span> <span class="matchup">${matchup}</span>`;
+    container.appendChild(title);
+
+    if (this.liveGame.venue) {
+      const venue = document.createElement("div");
+      venue.className = "venue";
+      venue.innerText = `${this.formatDateTime(this.liveGame.startTime)} • ${this.liveGame.venue}`;
+      container.appendChild(venue);
+    }
+
+    const table = document.createElement("table");
+    table.className = "stats-table";
+
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    ["Player", "MIN", "PTS", "REB", "AST", "STL"].forEach((label) => {
+      const th = document.createElement("th");
+      th.innerText = label;
+      headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement("tbody");
+    (this.liveGame.players || []).forEach((player) => {
+      const row = document.createElement("tr");
+
+      const nameCell = document.createElement("td");
+      nameCell.className = "player";
+      nameCell.innerText = player.name;
+      row.appendChild(nameCell);
+
+      const stats = [player.minutes, player.points, player.rebounds, player.assists, player.steals];
+      stats.forEach((value) => {
+        const td = document.createElement("td");
+        td.innerText = value || "-";
+        row.appendChild(td);
+      });
+
+      tbody.appendChild(row);
+    });
+
+    if (!tbody.hasChildNodes()) {
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+      cell.colSpan = 6;
+      cell.className = "no-data";
+      cell.innerText = "Live player stats are not currently available.";
+      row.appendChild(cell);
+      tbody.appendChild(row);
+    }
+
+    table.appendChild(tbody);
+    container.appendChild(table);
+
+    return container;
+  },
+
+  renderUpcoming() {
+    const container = document.createElement("div");
+    container.className = "upcoming";
+
+    const title = document.createElement("div");
+    title.className = "section-title";
+    title.innerText = `No live games. Next ${this.config.favoriteTeamDisplayName} matchups:`;
+    container.appendChild(title);
+
+    const list = document.createElement("ul");
+    list.className = "upcoming-list";
+
+    if (!this.upcomingGames || this.upcomingGames.length === 0) {
+      const li = document.createElement("li");
+      li.className = "no-data";
+      li.innerText = "No upcoming games found.";
+      list.appendChild(li);
+    } else {
+      this.upcomingGames.slice(0, this.config.maxUpcoming).forEach((game) => {
+        const li = document.createElement("li");
+        const prefix = game.isHome ? "vs" : "@";
+        li.innerHTML = `<span class="opponent">${prefix} ${game.opponent}</span><span class="datetime">${this.formatDateTime(game.date)}</span>`;
+        if (game.venue) {
+          const venue = document.createElement("div");
+          venue.className = "venue";
+          venue.innerText = game.venue;
+          li.appendChild(venue);
+        }
+        list.appendChild(li);
+      });
+    }
+
+    container.appendChild(list);
+    return container;
+  },
+
+  formatDateTime(dateString) {
+    if (!dateString) {
+      return "";
+    }
+
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+      return dateString;
+    }
+
+    const options = {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit"
+    };
+
+    return date.toLocaleString(undefined, options);
+  }
+});

--- a/MMM-WNBAFeverStats/README.md
+++ b/MMM-WNBAFeverStats/README.md
@@ -1,0 +1,78 @@
+# MMM-WNBAFeverStats
+
+MagicMirror² module that keeps Indiana Fever fans up to date with live WNBA player statistics and the next scheduled games. When the Fever are on the court the module shows real-time box score details for every player. Between games it highlights the next three matchups so you always know when to tune in.
+
+## Features
+
+- Live game detection powered by the public ESPN WNBA API.
+- Player level stat lines for points, rebounds, assists, steals, and minutes played.
+- Automatic scoreboard with opponent, venue, and current game clock description.
+- Upcoming schedule list (up to three entries) whenever no games are live.
+- Configurable favorite team identifier, title text, and update interval.
+
+## Installation
+
+1. Navigate to the `modules` directory of your MagicMirror² installation:
+
+   ```bash
+   cd ~/MagicMirror/modules
+   ```
+
+2. Clone or copy this repository into the modules folder and install dependencies:
+
+   ```bash
+   git clone <your-fork-url> MMM-WNBAFeverStats
+   cd MMM-WNBAFeverStats
+   npm install
+   ```
+
+   > **Note:** The module depends on the public ESPN API. Depending on your network setup you may need to allow outbound HTTPS requests for the MagicMirror² host.
+
+3. Configure the module in `config/config.js` as shown below.
+
+## Configuration
+
+Add the module to the `modules` array in your MagicMirror `config.js` file:
+
+```javascript
+{
+  module: "MMM-WNBAFeverStats",
+  position: "top_left",
+  config: {
+    favoriteTeamId: "ind", // ESPN identifier for the Indiana Fever
+    favoriteTeamDisplayName: "Indiana Fever",
+    headerText: "Indiana Fever Live Stats",
+    updateInterval: 5 * 60 * 1000, // 5 minutes
+    maxUpcoming: 3
+  }
+}
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `favoriteTeamId` | `string` | `"ind"` | Team identifier used by the ESPN API. The default is the Indiana Fever. |
+| `favoriteTeamDisplayName` | `string` | `"Indiana Fever"` | Friendly team name used within the UI. |
+| `headerText` | `string` | `"Indiana Fever Live Stats"` | Custom header text displayed by MagicMirror². |
+| `updateInterval` | `number` | `300000` | Refresh interval in milliseconds. Minimum enforced interval is 60 seconds. |
+| `maxUpcoming` | `number` | `3` | Maximum number of upcoming games to show when there is no live game. |
+
+## Data Sources
+
+All statistics and schedule information are fetched from the ESPN public WNBA endpoints:
+
+- `https://site.api.espn.com/apis/site/v2/sports/basketball/wnba/teams/{teamId}/schedule`
+- `https://site.api.espn.com/apis/site/v2/sports/basketball/wnba/summary?event={eventId}`
+
+The module gracefully handles network or data errors by showing an error message in the MagicMirror² interface.
+
+## Development Notes
+
+- The Node helper caches the module configuration and polls the ESPN API at the configured interval.
+- Player statistics are dynamically mapped based on the label names provided by the API so new fields can be added in the future with minimal changes.
+- Upcoming game entries show whether the Fever are home (`vs`) or away (`@`) and include the scheduled tip time using the MagicMirror host locale.
+
+## License
+
+MIT – see the [LICENSE](LICENSE) file for details.

--- a/MMM-WNBAFeverStats/node_helper.js
+++ b/MMM-WNBAFeverStats/node_helper.js
@@ -1,0 +1,227 @@
+const NodeHelper = require("node_helper");
+const fetch = require("node-fetch");
+
+module.exports = NodeHelper.create({
+  start() {
+    this.config = null;
+    this.updateTimer = null;
+  },
+
+  stop() {
+    if (this.updateTimer) {
+      clearInterval(this.updateTimer);
+    }
+  },
+
+  socketNotificationReceived(notification, payload) {
+    if (notification === "CONFIG") {
+      this.config = payload;
+      this.fetchGameData();
+      this.scheduleUpdates();
+    }
+  },
+
+  scheduleUpdates() {
+    if (!this.config) {
+      return;
+    }
+
+    if (this.updateTimer) {
+      clearInterval(this.updateTimer);
+    }
+
+    const interval = Math.max(parseInt(this.config.updateInterval, 10) || (5 * 60 * 1000), 60 * 1000);
+    this.updateTimer = setInterval(() => {
+      this.fetchGameData();
+    }, interval);
+  },
+
+  async fetchGameData() {
+    if (!this.config) {
+      return;
+    }
+
+    try {
+      const scheduleUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/wnba/teams/${this.config.favoriteTeamId}/schedule`;
+      const schedule = await this.fetchJson(scheduleUrl);
+      const events = Array.isArray(schedule.events) ? schedule.events : [];
+
+      const now = new Date();
+      let liveEvent = null;
+      const upcomingEvents = [];
+
+      events.forEach((event) => {
+        const competition = event.competitions && event.competitions[0];
+        if (!competition) {
+          return;
+        }
+
+        const status = competition.status && competition.status.type && competition.status.type.state;
+        const eventDate = event.date ? new Date(event.date) : null;
+
+        if (status === "in" && !liveEvent) {
+          liveEvent = event;
+        } else if (status === "pre" && eventDate && eventDate >= now) {
+          upcomingEvents.push(event);
+        }
+      });
+
+    const formattedUpcoming = upcomingEvents
+      .sort((a, b) => new Date(a.date) - new Date(b.date))
+      .slice(0, this.config.maxUpcoming || 3)
+      .map((event) => this.formatUpcoming(event))
+      .filter(Boolean);
+
+      let liveGame = null;
+      if (liveEvent) {
+        liveGame = await this.buildLiveGame(liveEvent);
+      }
+
+      this.sendSocketNotification("GAME_DATA", {
+        liveGame,
+        upcomingGames: formattedUpcoming
+      });
+    } catch (error) {
+      this.sendSocketNotification("GAME_ERROR", { message: error.message });
+    }
+  },
+
+  async buildLiveGame(event) {
+    const competition = event.competitions && event.competitions[0];
+    if (!competition) {
+      return null;
+    }
+
+    const summaryUrl = `https://site.api.espn.com/apis/site/v2/sports/basketball/wnba/summary?event=${event.id}`;
+    const summary = await this.fetchJson(summaryUrl);
+    const favorite = this.findFavoriteCompetitor(competition);
+    const opponent = this.findOpponent(competition, favorite);
+    const venue = competition.venue && (competition.venue.fullName || competition.venue.displayName);
+
+    const players = this.extractPlayerStats(summary.boxscore && summary.boxscore.players, this.config.favoriteTeamId);
+
+    return {
+      eventId: event.id,
+      status: (competition.status && (competition.status.type && (competition.status.type.detail || competition.status.type.shortDetail)))
+        || (event.status && event.status.type && event.status.type.detail)
+        || "Live",
+      startTime: event.date,
+      teamScore: favorite && favorite.score ? favorite.score : "0",
+      opponentScore: opponent && opponent.score ? opponent.score : "0",
+      opponent: opponent && opponent.team ? (opponent.team.displayName || opponent.team.shortDisplayName || opponent.team.name) : "Opponent",
+      venue: venue || "",
+      players
+    };
+  },
+
+  extractPlayerStats(playersData, favoriteTeamId) {
+    if (!Array.isArray(playersData)) {
+      return [];
+    }
+
+    const target = (favoriteTeamId || "").toLowerCase();
+
+    const teamEntry = playersData.find((entry) => {
+      const team = entry.team || {};
+      const candidates = [team.abbreviation, team.shortDisplayName, team.displayName, team.slug, team.id, team.uid];
+      return candidates
+        .filter(Boolean)
+        .map((value) => String(value).toLowerCase())
+        .includes(target);
+    });
+
+    if (!teamEntry || !Array.isArray(teamEntry.statistics)) {
+      return [];
+    }
+
+    const statsEntry = teamEntry.statistics.find((stat) => Array.isArray(stat.athletes));
+    if (!statsEntry || !Array.isArray(statsEntry.athletes)) {
+      return [];
+    }
+
+    const labels = Array.isArray(statsEntry.labels) ? statsEntry.labels : [];
+
+    return statsEntry.athletes.map((athlete) => {
+      const statLine = this.mapStats(labels, athlete.stats);
+      const info = athlete.athlete || {};
+      return {
+        id: info.id,
+        name: info.displayName || info.shortName || "Unknown",
+        position: info.position && info.position.abbreviation,
+        minutes: statLine.MIN || statLine.Minutes || "",
+        points: statLine.PTS || statLine.Points || "",
+        rebounds: statLine.REB || statLine.Rebounds || "",
+        assists: statLine.AST || statLine.Assists || "",
+        steals: statLine.STL || statLine.Steals || ""
+      };
+    });
+  },
+
+  mapStats(labels, stats) {
+    const result = {};
+    if (!Array.isArray(labels) || !Array.isArray(stats)) {
+      return result;
+    }
+
+    labels.forEach((label, index) => {
+      result[label] = stats[index];
+    });
+
+    return result;
+  },
+
+  formatUpcoming(event) {
+    const competition = event.competitions && event.competitions[0];
+    if (!competition) {
+      return null;
+    }
+
+    const favorite = this.findFavoriteCompetitor(competition);
+    const opponent = this.findOpponent(competition, favorite);
+    const venue = competition.venue && (competition.venue.fullName || competition.venue.displayName);
+
+    return {
+      id: event.id,
+      date: event.date,
+      opponent: opponent && opponent.team ? (opponent.team.displayName || opponent.team.shortDisplayName || opponent.team.name) : "Opponent",
+      venue: venue || "",
+      isHome: favorite ? favorite.homeAway === "home" : false
+    };
+  },
+
+  findFavoriteCompetitor(competition) {
+    const competitors = Array.isArray(competition.competitors) ? competition.competitors : [];
+    const target = (this.config.favoriteTeamId || "").toLowerCase();
+
+    return competitors.find((competitor) => {
+      if (!competitor.team) {
+        return false;
+      }
+
+      const team = competitor.team;
+      const candidates = [team.abbreviation, team.shortDisplayName, team.displayName, team.slug, team.id, team.uid];
+      return candidates
+        .filter(Boolean)
+        .map((value) => String(value).toLowerCase())
+        .includes(target);
+    }) || competitors[0];
+  },
+
+  findOpponent(competition, favorite) {
+    const competitors = Array.isArray(competition.competitors) ? competition.competitors : [];
+    if (!favorite) {
+      return competitors[1] || competitors[0] || null;
+    }
+
+    return competitors.find((competitor) => competitor !== favorite) || null;
+  },
+
+  async fetchJson(url) {
+    const response = await fetch(url, { headers: { "User-Agent": "MagicMirror-Module" } });
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    return response.json();
+  }
+});

--- a/MMM-WNBAFeverStats/package-lock.json
+++ b/MMM-WNBAFeverStats/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "mmm-wnbafeverstats",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mmm-wnbafeverstats",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/MMM-WNBAFeverStats/package.json
+++ b/MMM-WNBAFeverStats/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mmm-wnbafeverstats",
+  "version": "1.0.0",
+  "description": "MagicMirror² module that displays live Indiana Fever stats and upcoming games for the WNBA.",
+  "main": "MMM-WNBAFeverStats.js",
+  "keywords": [
+    "MagicMirror",
+    "MagicMirror2",
+    "WNBA",
+    "Indiana Fever",
+    "basketball",
+    "module"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "node-fetch": "^2.6.12"
+  }
+}


### PR DESCRIPTION
## Summary
- add a module-specific .gitignore to keep build artifacts and node_modules out of version control
- supply an MIT license file and reference it from the README for distribution clarity
- generate an npm lockfile to capture exact helper dependencies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1b983728c832e8e86411ef6dcb840